### PR TITLE
Extend callable interface to accept a request object as a second positional argument

### DIFF
--- a/aiohttp_catcher/catcher.py
+++ b/aiohttp_catcher/catcher.py
@@ -10,7 +10,6 @@ from aiohttp_catcher.scenario import Scenario
 LOGGER = logging.getLogger(__name__)
 
 
-
 async def get_full_class_name(cls: type) -> str:
     return f"{cls.__module__}.{cls.__name__}"
 
@@ -58,7 +57,7 @@ class Catcher:
                     scenario = Scenario(exceptions=[type(exc)])
                 additional_fields: Dict = await scenario.get_additional_fields(exc)
                 data = {
-                    self.envelope: await scenario.get_response_message(exc),
+                    self.envelope: await scenario.get_response_message(exc=exc),
                     self.code: scenario.status_code,
                     **additional_fields
                 }

--- a/aiohttp_catcher/catcher.py
+++ b/aiohttp_catcher/catcher.py
@@ -57,7 +57,7 @@ class Catcher:
                     scenario = Scenario(exceptions=[type(exc)])
                 additional_fields: Dict = await scenario.get_additional_fields(exc)
                 data = {
-                    self.envelope: await scenario.get_response_message(exc=exc),
+                    self.envelope: await scenario.get_response_message(exc=exc, request=request),
                     self.code: scenario.status_code,
                     **additional_fields
                 }

--- a/aiohttp_catcher/catcher.py
+++ b/aiohttp_catcher/catcher.py
@@ -55,7 +55,7 @@ class Catcher:
                 else:
                     LOGGER.exception("aiohttp-catcher caught an unhandled exception")
                     scenario = Scenario(exceptions=[type(exc)])
-                additional_fields: Dict = await scenario.get_additional_fields(exc)
+                additional_fields: Dict = await scenario.get_additional_fields(exc=exc, req=request)
                 data = {
                     self.envelope: await scenario.get_response_message(exc=exc, request=request),
                     self.code: scenario.status_code,

--- a/aiohttp_catcher/scenario.py
+++ b/aiohttp_catcher/scenario.py
@@ -12,7 +12,7 @@ class Scenario:
     stringify_exception: bool = False
     additional_fields: Union[Dict, Callable, Awaitable] = None
 
-    def __init__(self, exceptions: List[Exception], func: Union[Callable, Awaitable] = None, constant: Any = "Internal server error",
+    def __init__(self, exceptions: List[type[Exception]], func: Union[Callable, Awaitable] = None, constant: Any = "Internal server error",
                  stringify_exception: bool = False, status_code: int = 500,
                  additional_fields: Union[Dict, Callable, Awaitable] = None):
         self.exceptions = exceptions
@@ -65,5 +65,5 @@ class Scenario:
         return self
 
 
-def catch(*exceptions: Exception) -> Scenario:
+def catch(*exceptions: type[Exception]) -> Scenario:
     return Scenario(exceptions=list(exceptions))

--- a/aiohttp_catcher/scenario.py
+++ b/aiohttp_catcher/scenario.py
@@ -1,5 +1,7 @@
-from typing import Any, Awaitable, Callable, Dict, List, Union
+from typing import Any, Awaitable, Callable, Dict, List, Type, Union
 from inspect import isawaitable, iscoroutine, iscoroutinefunction
+
+from aiohttp.web import Request
 
 
 def is_async(f):
@@ -12,8 +14,8 @@ class Scenario:
     stringify_exception: bool = False
     additional_fields: Union[Dict, Callable, Awaitable] = None
 
-    def __init__(self, exceptions: List[type[Exception]], func: Union[Callable, Awaitable] = None, constant: Any = "Internal server error",
-                 stringify_exception: bool = False, status_code: int = 500,
+    def __init__(self, exceptions: List[Type[Exception]], func: Union[Callable, Awaitable] = None,
+                 constant: Any = "Internal server error", stringify_exception: bool = False, status_code: int = 500,
                  additional_fields: Union[Dict, Callable, Awaitable] = None):
         self.exceptions = exceptions
         self.stringify_exception = stringify_exception
@@ -25,11 +27,11 @@ class Scenario:
                 self.is_callable = True
         self.status_code = status_code
 
-    async def get_response_message(self, exc: Exception) -> Any:
+    async def get_response_message(self, exc: Exception, request: Request) -> Any:
         if self.is_callable:
             if is_async(self.func):
-                return await self.func(exc)
-            return self.func(exc)
+                return await self.func(exc, request)
+            return self.func(exc, request)
         if self.stringify_exception:
             return str(exc)
         return self.constant
@@ -65,5 +67,5 @@ class Scenario:
         return self
 
 
-def catch(*exceptions: type[Exception]) -> Scenario:
+def catch(*exceptions: Type[Exception]) -> Scenario:
     return Scenario(exceptions=list(exceptions))

--- a/aiohttp_catcher/scenario.py
+++ b/aiohttp_catcher/scenario.py
@@ -36,14 +36,14 @@ class Scenario:
             return str(exc)
         return self.constant
 
-    async def get_additional_fields(self, exc: Exception) -> Dict:
+    async def get_additional_fields(self, exc: Exception, req: Request) -> Dict:
         if not self.additional_fields:
             return {}
         if isinstance(self.additional_fields, Dict):
             return self.additional_fields
         if is_async(self.additional_fields):
-            return await self.additional_fields(exc)
-        return self.additional_fields(exc)
+            return await self.additional_fields(exc, req)
+        return self.additional_fields(exc, req)
 
     def with_status_code(self, status_code) -> "Scenario":
         self.status_code = status_code

--- a/tests/test_catcher.py
+++ b/tests/test_catcher.py
@@ -86,25 +86,6 @@ class TestCatcher:
         assert "User ID 1009 could not be found" == (await resp.json()).get("message")
 
     @staticmethod
-    async def test_invoke_blocking_callable(aiohttp_client, routes, loop):
-        catcher = Catcher()
-        await catcher.add_scenario(
-            catch(EntityNotFound).with_status_code(404).and_stringify()
-        )
-
-        app = web.Application(middlewares=[catcher.middleware])
-        app.add_routes(routes)
-
-        client = await aiohttp_client(app)
-        resp = await client.get("/user/1001")
-        assert 200 == resp.status
-        assert "Jayne Doe" == (await resp.json()).get("name")
-
-        resp = await client.get("/user/1009")
-        assert 404 == resp.status
-        assert "User ID 1009 could not be found" == (await resp.json()).get("message")
-
-    @staticmethod
     async def test_catch_parent_exception(aiohttp_client, routes, loop):
         catcher = Catcher()
         await catcher.add_scenario(


### PR DESCRIPTION
## [Extend callable interface to accept a request object as a second positional argument](https://github.com/yuvalherziger/aiohttp-catcher/issues/2)

Right now, the [Callables and Awaitables](https://github.com/yuvalherziger/aiohttp-catcher#callables-and-awaitables) feature invokes those functions with a single argument, which is the exception thrown from aiohttp handlers.  The goal of this feature is to add a second, optional positional argument for the aiohttp request object.  This will add an additional level of flexibility for callables-as-error-responses.

